### PR TITLE
fix: swap title and place in blockchain intern at ethereum foundation

### DIFF
--- a/components/Experience/component.tsx
+++ b/components/Experience/component.tsx
@@ -26,8 +26,8 @@ export const Experience: FC = () => {
         date: "Jun 2019 - Aug 2019",
       },
       {
-        title: "Ethereum Foundation",
-        place: "Blockchain Intern, Remote",
+        title: "Blockchain Intern",
+        place: "Ethereum Foundation, Remote",
         date: "Jun 2020 - Aug 2020",
       },
       {


### PR DESCRIPTION
Там похоже места свапнулись, везде сначала title потом place, но в ethereum наоборот почему-то